### PR TITLE
Fix measureElectricity loop increment

### DIFF
--- a/src-esp32/src/tasks/measure-electricity.h
+++ b/src-esp32/src/tasks/measure-electricity.h
@@ -51,9 +51,10 @@ void measureElectricity(void * parameter)
               NULL              // Task handle
             );
           #endif
+
+          measureIndex = 0;
       }
 
-      measureIndex = 0;
       long end = millis();
 
       // Schedule the task to run again in 1 second (while


### PR DESCRIPTION
as measureElectricity loops, it will push upstream to AWS/HA iff the measureIndex
is == the config.h LOCAL_MEASUREMENTS (30 by default, or every 30 measurements,
being every 30s). The reset of the measureIndex counter happens outside of the
check that the increment has reached its target, meaning every loop the index is
reset back to 0 and never reaches 30. Move the reset to 0 to the condition that
it reached its target.

(I may have some more ideas to contribute but wanted to get this quick fix to you as it was a hard blocker to this working for me)