### PR TITLE
Update serverless.yml to update AWS IOT ARN in Rule SQL

### DIFF
--- a/src-aws/serverless.yml
+++ b/src-aws/serverless.yml
@@ -143,10 +143,10 @@ resources:
           Description: "Forwards incoming sensor messages to DynamoDB for analysis"
           RuleDisabled: false
           Sql: >-
-            SELECT *, 
+            SELECT * ,
                   'reading-' + clientid() as primarykey, 
-                  (timestamp() / 1000) as sortkey,
-                  ((timestamp() / 1000) + 2592000) as ttl
+                  (timestamp() / 1000) as sortkey, 
+                  ((timestamp() / 1000) + 2592000) as ttl FROM '*** YOUR AWS IOT CORE THING ARN ***' 
 
     ###
     # Policy that defines what each sensor is allowed to do. On basic


### PR DESCRIPTION
Updated sql in AWS IOT RULE to user ARN. This resolves error where rule was not able to insert data in Dynamo DB.
For me whatever I tried, the rule was not saving data in DynamoDB. This resolved the issue and now data is getting stored in DB.