### PR TITLE
Included config file to enum

### DIFF
--- a/src-esp32/src/config/enums.h
+++ b/src-esp32/src/config/enums.h
@@ -2,6 +2,8 @@
 #define ENUMS
 
 #include <Arduino.h>
+#include "config.dist.h"
+
 
 // The state in which the device can be. This mainly affects what
 // is drawn on the display.


### PR DESCRIPTION
DEBUG == true is defined in config file which was not imported in the enum.h file.